### PR TITLE
Update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,7 +22,7 @@ venv
 /pip-wheel
 /pip-wheelhouse
 /pip-cache
-requirements.txt
+
 requirements.lock
 *.log
 


### PR DESCRIPTION
存在requirements.txt文件
导致docker-compose编译过程中找不到requirements.txt文件报错

failed to solve: failed to compute cache key: failed to calculate checksum of ref 6d327fcc-e467-4329-89ca-8abcd038a677::fppsgl2dbxims05cu7nzpmdmy: "/.requirements.txt": not found