### PR TITLE
改写中间件设置，支持FastAPI实例运行后修改cors参数

### DIFF
--- a/modules/api/api_setup.py
+++ b/modules/api/api_setup.py
@@ -73,6 +73,22 @@ def setup_api_args(parser: argparse.ArgumentParser):
         help="Exclude the specified API from the server",
     )
 
+import starlette
+def configure_cors_middleware(app: FastAPI, allow_origins: list = ["*"],
+        allow_credentials: bool = True,
+        allow_methods: list = ["*"],
+        allow_headers: list = ["*"],):
+    from starlette.middleware.cors import CORSMiddleware
+
+    cors_options = {
+        "allow_methods": allow_methods,
+        "allow_headers": allow_headers,
+        "allow_credentials": allow_credentials,
+        "allow_origins": allow_origins,
+    }
+
+    app.user_middleware.insert(0, starlette.middleware.Middleware(CORSMiddleware, **cors_options))
+    app.build_middleware_stack()  # rebuild middleware stack on-the-fly
 
 def process_api_args(args: argparse.Namespace, app: FastAPI):
     cors_origin = env.get_and_update_env(args, "cors_origin", "*", str)
@@ -84,7 +100,7 @@ def process_api_args(args: argparse.Namespace, app: FastAPI):
     config.api = api
 
     if cors_origin:
-        api.set_cors(allow_origins=[cors_origin])
+        configure_cors_middleware(app, allow_origins=[cors_origin])
         logger.info(f"allow CORS origin: {cors_origin}")
 
     if not no_playground:


### PR DESCRIPTION
原始的api.set_cors(allow_origins=[cors_origin])会因为 webui.py中调用了demo.queue().launch()，返回FastAPI的实例app处于运行状态，无法添加中间件函数造成运行错误而崩溃。
`
Traceback (most recent call last):
  File "/app/Speech-AI-Forge/webui.py", line 178, in <module>
    process_webui_args(args)
  File "/app/Speech-AI-Forge/webui.py", line 156, in process_webui_args
    process_api_args(args, app)
  File "/app/Speech-AI-Forge/modules/api/api_setup.py", line 87, in process_api_args
    api.set_cors(allow_origins=[cors_origin])
  File "/app/Speech-AI-Forge/modules/api/Api.py", line 101, in set_cors
    @self.app.middleware("http")
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/fastapi/applications.py", line 4535, in decorator
    self.add_middleware(BaseHTTPMiddleware, dispatch=func)
  File "/opt/conda/lib/python3.11/site-packages/starlette/applications.py", line 141, in add_middleware
    raise RuntimeError("Cannot add middleware after an application has started")
RuntimeError: Cannot add middleware after an application has started
`