### PR TITLE
feat: add MiniMax Cloud TTS as cloud-based TTS provider

### DIFF
--- a/.env.api
+++ b/.env.api
@@ -38,3 +38,7 @@ EXCLUDE=
 
 # Model configuration
 AUTO_DOWNLOAD=False
+
+# MiniMax Cloud TTS (optional, for minimax-hd / minimax-turbo models)
+# Get your API key from https://platform.minimaxi.com/
+MINIMAX_API_KEY=

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ python launch.py
 |                 | [Spark-TTS](https://github.com/SparkAudio/Spark-TTS)               | en, zh              | ✅           |
 |                 | [GPT-SoVITS](https://github.com/RVC-Boss/GPT-SoVITS/tree/main)     | en, zh, ja, ko, yue | ✅           |
 |          | [ChatTTS](https://github.com/2noise/ChatTTS)                       | en, zh              | ✅           |
+| **Cloud TTS**   |                        |                   |            |
+|                 | [MiniMax Cloud TTS](https://platform.minimaxi.com/)                | en, zh, jp, ko + more | ✅ (speech-2.8-hd/turbo) |
 | **ASR**         |                        |                   |            |
 |          | [Whisper](https://github.com/openai/whisper)                       | ✅                  | ✅           |
 |                 | [SenseVoice](https://github.com/FunAudioLLM/SenseVoice)            | ✅                  | ✅           |

--- a/modules/core/models/tts/MiniMaxCloudTTSModel.py
+++ b/modules/core/models/tts/MiniMaxCloudTTSModel.py
@@ -1,0 +1,232 @@
+import io
+import logging
+import os
+from typing import Generator
+
+import numpy as np
+import requests
+from pydub import AudioSegment as PydubSegment
+
+from modules.core.models.TTSModel import TTSModel
+from modules.core.pipeline.dcls import TTSPipelineContext, TTSSegment
+from modules.core.pipeline.processor import NP_AUDIO
+
+logger = logging.getLogger(__name__)
+
+# Verified MiniMax TTS voice IDs
+MINIMAX_VOICE_IDS = [
+    "English_Graceful_Lady",
+    "English_Insightful_Speaker",
+    "English_radiant_girl",
+    "English_Persuasive_Man",
+    "English_Lucky_Robot",
+    "Wise_Woman",
+    "cute_boy",
+    "lovely_girl",
+    "Friendly_Person",
+    "Inspirational_girl",
+    "Deep_Voice_Man",
+    "sweet_girl",
+]
+
+MINIMAX_TTS_API_URL = "https://api.minimax.io/v1/t2a_v2"
+
+
+class MiniMaxCloudTTSModel(TTSModel):
+    """MiniMax Cloud TTS model using MiniMax T2A v2 API.
+
+    This is a cloud-based TTS model that calls MiniMax's text-to-audio API
+    instead of running local model inference. No GPU or model download required.
+
+    Supported models:
+    - speech-2.8-hd: Higher quality, slower
+    - speech-2.8-turbo: Faster, slightly lower quality
+
+    Requires MINIMAX_API_KEY environment variable to be set.
+    """
+
+    def __init__(self, model_variant: str = "speech-2.8-hd") -> None:
+        model_id = (
+            "minimax-hd" if model_variant == "speech-2.8-hd" else "minimax-turbo"
+        )
+        super().__init__(model_id=model_id, model_name=model_variant)
+
+        self.model_variant = model_variant
+        self._loaded = False
+
+    def _get_api_key(self) -> str:
+        api_key = os.environ.get("MINIMAX_API_KEY", "")
+        if not api_key:
+            raise RuntimeError(
+                "MINIMAX_API_KEY environment variable is not set. "
+                "Get your API key from https://platform.minimaxi.com/"
+            )
+        return api_key
+
+    def is_loaded(self) -> bool:
+        return self._loaded
+
+    def load(self) -> None:
+        # Verify API key is available
+        self._get_api_key()
+        self._loaded = True
+        logger.info(f"MiniMax Cloud TTS ({self.model_variant}) ready.")
+
+    def unload(self) -> None:
+        self._loaded = False
+
+    def is_downloaded(self, verbose=True) -> bool:
+        # Cloud model - always "downloaded" if API key is set
+        api_key = os.environ.get("MINIMAX_API_KEY", "")
+        if not api_key:
+            if verbose:
+                logger.warning(
+                    "MINIMAX_API_KEY not set. Set it to use MiniMax Cloud TTS."
+                )
+            return False
+        return True
+
+    def can_auto_download(self) -> bool:
+        # No download needed for cloud model
+        return False
+
+    def download(self, force=False):
+        # No-op for cloud model
+        return None
+
+    def get_sample_rate(self) -> int:
+        # MiniMax TTS returns MP3 audio; after decoding we resample to 24000
+        return 24000
+
+    def _get_voice_id(self, segment: TTSSegment) -> str:
+        """Resolve voice ID from segment speaker or use default."""
+        if segment.spk is not None:
+            spk_name = segment.spk.name if hasattr(segment.spk, "name") else ""
+            # Check if speaker name matches a MiniMax voice ID
+            if spk_name in MINIMAX_VOICE_IDS:
+                return spk_name
+            # Check speaker description or custom field
+            if hasattr(segment.spk, "desc") and segment.spk.desc:
+                desc = segment.spk.desc
+                for vid in MINIMAX_VOICE_IDS:
+                    if vid.lower() in desc.lower():
+                        return vid
+
+        # Use emotion as voice hint if available
+        emotion = segment.emotion or ""
+        if emotion:
+            emotion_lower = emotion.lower()
+            if "male" in emotion_lower or "man" in emotion_lower:
+                return "English_Persuasive_Man"
+            elif "robot" in emotion_lower:
+                return "English_Lucky_Robot"
+            elif "girl" in emotion_lower or "cute" in emotion_lower:
+                return "lovely_girl"
+
+        return "Friendly_Person"
+
+    def _call_tts_api(self, text: str, voice_id: str, speed: float = 1.0) -> bytes:
+        """Call MiniMax TTS API and return raw audio bytes (MP3)."""
+        api_key = self._get_api_key()
+
+        payload = {
+            "model": self.model_variant,
+            "text": text,
+            "voice_setting": {
+                "voice_id": voice_id,
+                "speed": speed,
+            },
+            "audio_setting": {
+                "format": "mp3",
+            },
+        }
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        response = requests.post(
+            MINIMAX_TTS_API_URL,
+            json=payload,
+            headers=headers,
+            timeout=60,
+        )
+        response.raise_for_status()
+
+        result = response.json()
+
+        # Check for API errors
+        base_resp = result.get("base_resp", {})
+        if base_resp.get("status_code", 0) != 0:
+            error_msg = base_resp.get("status_msg", "Unknown error")
+            raise RuntimeError(f"MiniMax TTS API error: {error_msg}")
+
+        # Extract hex-encoded audio data
+        audio_hex = result.get("data", {}).get("audio", "")
+        if not audio_hex:
+            raise RuntimeError("MiniMax TTS API returned empty audio data")
+
+        return bytes.fromhex(audio_hex)
+
+    def _mp3_bytes_to_np_audio(self, mp3_bytes: bytes) -> NP_AUDIO:
+        """Convert MP3 bytes to NP_AUDIO (sample_rate, numpy_array)."""
+        audio_segment = PydubSegment.from_mp3(io.BytesIO(mp3_bytes))
+
+        # Convert to target sample rate
+        target_sr = self.get_sample_rate()
+        if audio_segment.frame_rate != target_sr:
+            audio_segment = audio_segment.set_frame_rate(target_sr)
+
+        # Convert to mono
+        if audio_segment.channels > 1:
+            audio_segment = audio_segment.set_channels(1)
+
+        # Convert to numpy float32 array
+        samples = np.array(audio_segment.get_array_of_samples(), dtype=np.float32)
+        samples = samples / np.iinfo(np.int16).max
+
+        return (target_sr, samples)
+
+    def generate_batch(
+        self, segments: list[TTSSegment], context: TTSPipelineContext
+    ) -> list[NP_AUDIO]:
+        cached = self.get_cache(segments=segments, context=context)
+        if cached is not None:
+            return cached
+
+        self.load()
+
+        results = []
+        for segment in segments:
+            if context.stop:
+                break
+
+            voice_id = self._get_voice_id(segment)
+            text = segment.text
+            if not text.strip():
+                # Return silence for empty text
+                sr = self.get_sample_rate()
+                results.append((sr, np.zeros(int(sr * 0.1), dtype=np.float32)))
+                continue
+
+            logger.info(
+                f"MiniMax Cloud TTS: generating with model={self.model_variant}, "
+                f"voice={voice_id}, text_len={len(text)}"
+            )
+
+            mp3_bytes = self._call_tts_api(text=text, voice_id=voice_id)
+            np_audio = self._mp3_bytes_to_np_audio(mp3_bytes)
+            results.append(np_audio)
+
+        if not context.stop:
+            self.set_cache(segments=segments, context=context, value=results)
+
+        return results
+
+    def generate_batch_stream(
+        self, segments: list[TTSSegment], context: TTSPipelineContext
+    ) -> Generator[list[NP_AUDIO], None, None]:
+        # MiniMax TTS API doesn't support streaming; yield full result
+        results = self.generate_batch(segments, context)
+        yield results

--- a/modules/core/models/zoo/ModelZoo.py
+++ b/modules/core/models/zoo/ModelZoo.py
@@ -19,6 +19,7 @@ from modules.core.models.tts.F5TtsModel import F5TtsModel
 from modules.core.models.tts.FireRed.FireRedTTSModel import FireRedTTSModel
 from modules.core.models.tts.GptSoVits.GptSoVitsModel import GptSoVitsModel
 from modules.core.models.tts.IndexTTS.IndexTTSV2Model import IndexTTSV2Model
+from modules.core.models.tts.MiniMaxCloudTTSModel import MiniMaxCloudTTSModel
 from modules.core.models.tts.Qwen.Qwen3TTS import Qwen3TTSModel
 from modules.core.models.tts.fishspeech.FishSpeech14Model import FishSpeech14Model
 from modules.core.models.tts.IndexTTS.IndexTTSModel import IndexTTSModel
@@ -67,6 +68,9 @@ class ModelZoo:
         "qwen3-tts-17cv": Qwen3TTSModel("1.7B-CustomVoice"),
         "qwen3-tts-17base": Qwen3TTSModel("1.7B-Base"),
         "qwen3-tts-17vd": Qwen3TTSModel("1.7B-VoiceDesign"),
+        # === cloud tts ===
+        "minimax-hd": MiniMaxCloudTTSModel("speech-2.8-hd"),
+        "minimax-turbo": MiniMaxCloudTTSModel("speech-2.8-turbo"),
         # === enhancer ===
         "resemble-enhance": ResembleEnhanceModel(),
         # === whisper ===
@@ -240,6 +244,12 @@ class ModelZoo:
 
     def get_qwen3_tts_17vd(self) -> Qwen3TTSModel:
         return self.get_model("qwen3-tts-17vd")
+
+    def get_minimax_hd(self) -> MiniMaxCloudTTSModel:
+        return self.get_model("minimax-hd")
+
+    def get_minimax_turbo(self) -> MiniMaxCloudTTSModel:
+        return self.get_model("minimax-turbo")
 
 
 model_zoo = ModelZoo()

--- a/modules/core/pipeline/factory.py
+++ b/modules/core/pipeline/factory.py
@@ -139,6 +139,8 @@ class PipelineFactory:
             return cls.create_gpt_sovits_v4(ctx)
         elif model_id.startswith("qwen3tts"):
             return cls.create_qwen3_tts_pipeline(ctx)
+        elif model_id.startswith("minimax"):
+            return cls.create_minimax_cloud_pipeline(ctx)
         else:
             raise Exception(f"Unknown model id: {model_id}")
 
@@ -283,6 +285,23 @@ class PipelineFactory:
         else:
             # 不支持
             raise ValueError(f"Unsupported model_id: {model_id}")
+        pipeline.set_model(model)
+
+        pipeline.audio_sr = model.get_sample_rate()
+        return pipeline
+
+    @classmethod
+    def create_minimax_cloud_pipeline(cls, ctx: TTSPipelineContext):
+        model_id = ctx.tts_config.mid.lower().replace(" ", "-").replace("-", "")
+
+        pipeline = TTSPipeline(ctx)
+        cls.setup_base_modules(pipeline=pipeline)
+        # Cloud TTS handles text directly, use base TN for minimal preprocessing
+        pipeline.add_module(TNProcess(tn_pipeline=BaseTN))
+        if model_id == "minimaxturbo":
+            model = model_zoo.get_minimax_turbo()
+        else:
+            model = model_zoo.get_minimax_hd()
         pipeline.set_model(model)
 
         pipeline.audio_sr = model.get_sample_rate()

--- a/tests/model/test_minimax_cloud_tts.py
+++ b/tests/model/test_minimax_cloud_tts.py
@@ -1,0 +1,481 @@
+"""Unit tests for MiniMax Cloud TTS model.
+
+These tests mock the MiniMax API to verify model behavior without making
+actual API calls. Run from project root:
+
+    python -m pytest tests/model/test_minimax_cloud_tts.py -v
+"""
+
+import io
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from pydub import AudioSegment as PydubSegment
+
+
+def _make_mp3_bytes(duration_ms=100, sample_rate=24000):
+    """Create minimal valid MP3 bytes for testing."""
+    samples = np.zeros(int(sample_rate * duration_ms / 1000), dtype=np.int16)
+    segment = PydubSegment(
+        samples.tobytes(),
+        frame_rate=sample_rate,
+        sample_width=2,
+        channels=1,
+    )
+    buffer = io.BytesIO()
+    segment.export(buffer, format="mp3")
+    return buffer.getvalue()
+
+
+def _make_api_response(mp3_bytes):
+    """Create a mock MiniMax TTS API response."""
+    return {
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+        "data": {"audio": mp3_bytes.hex()},
+    }
+
+
+# ---------- lazy import helper to bypass heavy deps ----------
+
+_module = None
+
+
+def _get_module():
+    """Import the MiniMax Cloud TTS module, handling import failures gracefully."""
+    global _module
+    if _module is not None:
+        return _module
+
+    # Ensure project root is on path
+    project_root = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+
+    # We need to mock heavy dependencies that the import chain pulls in
+    # The MiniMaxCloudTTSModel itself only needs: TTSModel base, dcls, processor
+    # But TTSModel imports BaseZooModel which imports AutoModelDownloader, etc.
+    # We'll mock the modules that require torch/torchaudio
+
+    mock_modules = {}
+    for mod_name in [
+        "modules.repos_static",
+        "modules.repos_static.sys_paths",
+        "modules.devices",
+        "modules.downloader",
+        "modules.downloader.AutoModelDownloader",
+        "modules.downloader.dl_base",
+        "modules.downloader.dl_registry",
+        "modules.downloader.dls",
+        "torchaudio",
+        "torchaudio.transforms",
+        "torch",
+    ]:
+        if mod_name not in sys.modules:
+            mock_modules[mod_name] = MagicMock()
+
+    with patch.dict(sys.modules, mock_modules):
+        # Mock devices module functions
+        devices_mock = sys.modules.get("modules.devices", MagicMock())
+        devices_mock.devices = MagicMock()
+        devices_mock.devices.after_gc = lambda: (lambda f: f)
+        devices_mock.devices.get_device_for = MagicMock(return_value="cpu")
+        devices_mock.devices.dtype = "float32"
+
+        # Mock AutoModelDownloader
+        adl_mock = sys.modules.get(
+            "modules.downloader.AutoModelDownloader", MagicMock()
+        )
+        adl_mock.AutoModelDownloader = MagicMock
+
+        from modules.core.models.tts.MiniMaxCloudTTSModel import (
+            MINIMAX_TTS_API_URL,
+            MINIMAX_VOICE_IDS,
+            MiniMaxCloudTTSModel,
+        )
+
+        _module = type(
+            "Module",
+            (),
+            {
+                "MiniMaxCloudTTSModel": MiniMaxCloudTTSModel,
+                "MINIMAX_VOICE_IDS": MINIMAX_VOICE_IDS,
+                "MINIMAX_TTS_API_URL": MINIMAX_TTS_API_URL,
+            },
+        )
+        return _module
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return _get_module()
+
+
+# ==================== Tests ====================
+
+
+class TestMiniMaxCloudTTSModelInit:
+    def test_hd_model_init(self, mod):
+        model = mod.MiniMaxCloudTTSModel("speech-2.8-hd")
+        assert model.model_id == "minimax-hd"
+        assert model.model_variant == "speech-2.8-hd"
+
+    def test_turbo_model_init(self, mod):
+        model = mod.MiniMaxCloudTTSModel("speech-2.8-turbo")
+        assert model.model_id == "minimax-turbo"
+        assert model.model_variant == "speech-2.8-turbo"
+
+    def test_default_model_init(self, mod):
+        model = mod.MiniMaxCloudTTSModel()
+        assert model.model_id == "minimax-hd"
+        assert model.model_variant == "speech-2.8-hd"
+
+    def test_sample_rate(self, mod):
+        model = mod.MiniMaxCloudTTSModel()
+        assert model.get_sample_rate() == 24000
+
+    def test_not_loaded_initially(self, mod):
+        model = mod.MiniMaxCloudTTSModel()
+        assert not model.is_loaded()
+
+
+class TestMiniMaxCloudTTSModelApiKey:
+    def test_is_downloaded_with_key(self, mod):
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}):
+            model = mod.MiniMaxCloudTTSModel()
+            assert model.is_downloaded(verbose=False)
+
+    def test_is_downloaded_without_key(self, mod):
+        env = os.environ.copy()
+        env.pop("MINIMAX_API_KEY", None)
+        with patch.dict(os.environ, env, clear=True):
+            model = mod.MiniMaxCloudTTSModel()
+            assert not model.is_downloaded(verbose=False)
+
+    def test_load_with_key(self, mod):
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}):
+            model = mod.MiniMaxCloudTTSModel()
+            model.load()
+            assert model.is_loaded()
+
+    def test_load_without_key_raises(self, mod):
+        env = os.environ.copy()
+        env.pop("MINIMAX_API_KEY", None)
+        with patch.dict(os.environ, env, clear=True):
+            model = mod.MiniMaxCloudTTSModel()
+            with pytest.raises(RuntimeError, match="MINIMAX_API_KEY"):
+                model.load()
+
+    def test_unload(self, mod):
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}):
+            model = mod.MiniMaxCloudTTSModel()
+            model.load()
+            assert model.is_loaded()
+            model.unload()
+            assert not model.is_loaded()
+
+    def test_can_auto_download(self, mod):
+        model = mod.MiniMaxCloudTTSModel()
+        assert not model.can_auto_download()
+
+    def test_download_returns_none(self, mod):
+        model = mod.MiniMaxCloudTTSModel()
+        assert model.download() is None
+
+
+class TestMiniMaxCloudTTSModelVoiceResolution:
+    def test_default_voice(self, mod):
+        from modules.core.pipeline.dcls import TTSSegment
+
+        model = mod.MiniMaxCloudTTSModel()
+        segment = TTSSegment(_type="audio", text="test")
+        voice = model._get_voice_id(segment)
+        assert voice == "Friendly_Person"
+
+    def test_voice_from_speaker_name(self, mod):
+        from modules.core.pipeline.dcls import TTSSegment
+
+        model = mod.MiniMaxCloudTTSModel()
+        segment = TTSSegment(_type="audio", text="test")
+        spk = MagicMock()
+        spk.name = "English_Graceful_Lady"
+        segment.spk = spk
+        voice = model._get_voice_id(segment)
+        assert voice == "English_Graceful_Lady"
+
+    def test_voice_from_emotion_male(self, mod):
+        from modules.core.pipeline.dcls import TTSSegment
+
+        model = mod.MiniMaxCloudTTSModel()
+        segment = TTSSegment(_type="audio", text="test", emotion="male narrator")
+        voice = model._get_voice_id(segment)
+        assert voice == "English_Persuasive_Man"
+
+    def test_voice_from_emotion_girl(self, mod):
+        from modules.core.pipeline.dcls import TTSSegment
+
+        model = mod.MiniMaxCloudTTSModel()
+        segment = TTSSegment(_type="audio", text="test", emotion="cute girl")
+        voice = model._get_voice_id(segment)
+        assert voice == "lovely_girl"
+
+    def test_voice_from_emotion_robot(self, mod):
+        from modules.core.pipeline.dcls import TTSSegment
+
+        model = mod.MiniMaxCloudTTSModel()
+        segment = TTSSegment(_type="audio", text="test", emotion="robot voice")
+        voice = model._get_voice_id(segment)
+        assert voice == "English_Lucky_Robot"
+
+
+class TestMiniMaxCloudTTSModelApiCall:
+    def test_call_tts_api_success(self, mod):
+        model = mod.MiniMaxCloudTTSModel("speech-2.8-hd")
+        mp3_bytes = _make_mp3_bytes()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = _make_api_response(mp3_bytes)
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}):
+            with patch(
+                "modules.core.models.tts.MiniMaxCloudTTSModel.requests.post",
+                return_value=mock_response,
+            ) as mock_post:
+                result = model._call_tts_api("Hello world", "Friendly_Person")
+
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        assert call_kwargs[1]["json"]["model"] == "speech-2.8-hd"
+        assert call_kwargs[1]["json"]["text"] == "Hello world"
+        assert (
+            call_kwargs[1]["json"]["voice_setting"]["voice_id"] == "Friendly_Person"
+        )
+
+    def test_call_tts_api_error_response(self, mod):
+        model = mod.MiniMaxCloudTTSModel("speech-2.8-hd")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "base_resp": {"status_code": 1000, "status_msg": "Invalid API key"},
+            "data": {"audio": ""},
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "bad-key"}):
+            with patch(
+                "modules.core.models.tts.MiniMaxCloudTTSModel.requests.post",
+                return_value=mock_response,
+            ):
+                with pytest.raises(RuntimeError, match="MiniMax TTS API error"):
+                    model._call_tts_api("Hello", "Friendly_Person")
+
+    def test_call_tts_api_empty_audio(self, mod):
+        model = mod.MiniMaxCloudTTSModel("speech-2.8-hd")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+            "data": {"audio": ""},
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}):
+            with patch(
+                "modules.core.models.tts.MiniMaxCloudTTSModel.requests.post",
+                return_value=mock_response,
+            ):
+                with pytest.raises(RuntimeError, match="empty audio"):
+                    model._call_tts_api("Hello", "Friendly_Person")
+
+    def test_turbo_model_sends_correct_variant(self, mod):
+        model = mod.MiniMaxCloudTTSModel("speech-2.8-turbo")
+        mp3_bytes = _make_mp3_bytes()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = _make_api_response(mp3_bytes)
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}):
+            with patch(
+                "modules.core.models.tts.MiniMaxCloudTTSModel.requests.post",
+                return_value=mock_response,
+            ) as mock_post:
+                model._call_tts_api("Hello", "Friendly_Person")
+
+        call_kwargs = mock_post.call_args
+        assert call_kwargs[1]["json"]["model"] == "speech-2.8-turbo"
+
+
+class TestMiniMaxCloudTTSModelMp3Conversion:
+    def test_mp3_bytes_to_np_audio(self, mod):
+        model = mod.MiniMaxCloudTTSModel()
+        mp3_bytes = _make_mp3_bytes(duration_ms=200)
+        sr, samples = model._mp3_bytes_to_np_audio(mp3_bytes)
+        assert sr == 24000
+        assert isinstance(samples, np.ndarray)
+        assert samples.dtype == np.float32
+        assert len(samples) > 0
+
+    def test_mp3_bytes_to_np_audio_mono(self, mod):
+        # Create stereo MP3 and verify it gets converted to mono
+        model = mod.MiniMaxCloudTTSModel()
+        samples = np.zeros((48000, 2), dtype=np.int16)
+        segment = PydubSegment(
+            samples.tobytes(),
+            frame_rate=48000,
+            sample_width=2,
+            channels=2,
+        )
+        buffer = io.BytesIO()
+        segment.export(buffer, format="mp3")
+        mp3_bytes = buffer.getvalue()
+
+        sr, result = model._mp3_bytes_to_np_audio(mp3_bytes)
+        assert sr == 24000
+        assert result.ndim == 1  # mono
+
+
+class TestMiniMaxCloudTTSModelGenerateBatch:
+    def test_generate_batch_single_segment(self, mod):
+        from modules.core.pipeline.dcls import TTSPipelineContext, TTSSegment
+
+        model = mod.MiniMaxCloudTTSModel()
+        mp3_bytes = _make_mp3_bytes()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = _make_api_response(mp3_bytes)
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}):
+            with patch(
+                "modules.core.models.tts.MiniMaxCloudTTSModel.requests.post",
+                return_value=mock_response,
+            ):
+                segment = TTSSegment(_type="audio", text="Hello world")
+                context = TTSPipelineContext()
+                context.infer_config.no_cache = True
+                results = model.generate_batch([segment], context)
+
+        assert len(results) == 1
+        sr, samples = results[0]
+        assert sr == 24000
+        assert isinstance(samples, np.ndarray)
+
+    def test_generate_batch_multiple_segments(self, mod):
+        from modules.core.pipeline.dcls import TTSPipelineContext, TTSSegment
+
+        model = mod.MiniMaxCloudTTSModel()
+        mp3_bytes = _make_mp3_bytes()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = _make_api_response(mp3_bytes)
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}):
+            with patch(
+                "modules.core.models.tts.MiniMaxCloudTTSModel.requests.post",
+                return_value=mock_response,
+            ) as mock_post:
+                segments = [
+                    TTSSegment(_type="audio", text="Hello"),
+                    TTSSegment(_type="audio", text="World"),
+                ]
+                context = TTSPipelineContext()
+                context.infer_config.no_cache = True
+                results = model.generate_batch(segments, context)
+
+        assert len(results) == 2
+        assert mock_post.call_count == 2
+
+    def test_generate_batch_empty_text(self, mod):
+        from modules.core.pipeline.dcls import TTSPipelineContext, TTSSegment
+
+        model = mod.MiniMaxCloudTTSModel()
+
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}):
+            segment = TTSSegment(_type="audio", text="   ")
+            context = TTSPipelineContext()
+            context.infer_config.no_cache = True
+            results = model.generate_batch([segment], context)
+
+        assert len(results) == 1
+        sr, samples = results[0]
+        assert sr == 24000
+        assert len(samples) > 0  # silence
+
+    def test_generate_batch_respects_stop(self, mod):
+        from modules.core.pipeline.dcls import TTSPipelineContext, TTSSegment
+
+        model = mod.MiniMaxCloudTTSModel()
+
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}):
+            segments = [
+                TTSSegment(_type="audio", text="Hello"),
+                TTSSegment(_type="audio", text="World"),
+            ]
+            context = TTSPipelineContext()
+            context.infer_config.no_cache = True
+            context.stop = True
+            results = model.generate_batch(segments, context)
+
+        assert len(results) == 0
+
+    def test_generate_batch_stream(self, mod):
+        from modules.core.pipeline.dcls import TTSPipelineContext, TTSSegment
+
+        model = mod.MiniMaxCloudTTSModel()
+        mp3_bytes = _make_mp3_bytes()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = _make_api_response(mp3_bytes)
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}):
+            with patch(
+                "modules.core.models.tts.MiniMaxCloudTTSModel.requests.post",
+                return_value=mock_response,
+            ):
+                segment = TTSSegment(_type="audio", text="Hello")
+                context = TTSPipelineContext()
+                context.infer_config.no_cache = True
+                batches = list(model.generate_batch_stream([segment], context))
+
+        assert len(batches) == 1
+        assert len(batches[0]) == 1
+
+
+class TestMiniMaxVoiceIds:
+    def test_voice_ids_not_empty(self, mod):
+        assert len(mod.MINIMAX_VOICE_IDS) > 0
+
+    def test_friendly_person_in_list(self, mod):
+        assert "Friendly_Person" in mod.MINIMAX_VOICE_IDS
+
+    def test_no_invalid_chinese_voices(self, mod):
+        invalid = [
+            "Chinese_Empress",
+            "Chinese_Gentle_Boy",
+            "Chinese_Cute_Girl",
+            "Chinese_Storyteller_Male",
+        ]
+        for v in invalid:
+            assert v not in mod.MINIMAX_VOICE_IDS
+
+
+class TestMiniMaxApiUrl:
+    def test_api_url(self, mod):
+        assert mod.MINIMAX_TTS_API_URL == "https://api.minimax.io/v1/t2a_v2"

--- a/tests/model/test_minimax_cloud_tts_integration.py
+++ b/tests/model/test_minimax_cloud_tts_integration.py
@@ -1,0 +1,81 @@
+"""Integration tests for MiniMax Cloud TTS model.
+
+These tests make actual API calls to the MiniMax TTS API.
+They require the MINIMAX_API_KEY environment variable to be set.
+
+Run with: pytest tests/model/test_minimax_cloud_tts_integration.py -m minimax_integration
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+from modules.core.models.tts.MiniMaxCloudTTSModel import MiniMaxCloudTTSModel
+from modules.core.pipeline.dcls import TTSPipelineContext, TTSSegment
+
+pytestmark = pytest.mark.minimax_integration
+
+SKIP_REASON = "MINIMAX_API_KEY not set; skipping MiniMax integration tests"
+
+
+@pytest.fixture
+def api_key():
+    key = os.environ.get("MINIMAX_API_KEY", "")
+    if not key:
+        pytest.skip(SKIP_REASON)
+    return key
+
+
+@pytest.fixture
+def hd_model(api_key):
+    model = MiniMaxCloudTTSModel("speech-2.8-hd")
+    model.load()
+    return model
+
+
+@pytest.fixture
+def turbo_model(api_key):
+    model = MiniMaxCloudTTSModel("speech-2.8-turbo")
+    model.load()
+    return model
+
+
+class TestMiniMaxCloudTTSIntegration:
+    def test_hd_model_generate(self, hd_model):
+        segment = TTSSegment(_type="audio", text="Hello, this is a test.")
+        context = TTSPipelineContext()
+        context.infer_config.no_cache = True
+
+        results = hd_model.generate_batch([segment], context)
+
+        assert len(results) == 1
+        sr, samples = results[0]
+        assert sr == 24000
+        assert isinstance(samples, np.ndarray)
+        assert samples.dtype == np.float32
+        assert len(samples) > 1000  # should have substantial audio
+
+    def test_turbo_model_generate(self, turbo_model):
+        segment = TTSSegment(_type="audio", text="Quick test for turbo model.")
+        context = TTSPipelineContext()
+        context.infer_config.no_cache = True
+
+        results = turbo_model.generate_batch([segment], context)
+
+        assert len(results) == 1
+        sr, samples = results[0]
+        assert sr == 24000
+        assert len(samples) > 1000
+
+    def test_chinese_text(self, hd_model):
+        segment = TTSSegment(_type="audio", text="你好，这是一个测试。")
+        context = TTSPipelineContext()
+        context.infer_config.no_cache = True
+
+        results = hd_model.generate_batch([segment], context)
+
+        assert len(results) == 1
+        sr, samples = results[0]
+        assert sr == 24000
+        assert len(samples) > 1000


### PR DESCRIPTION
## Summary

Add [MiniMax Cloud TTS](https://platform.minimaxi.com/) as a cloud-based TTS backend provider alongside existing local models (ChatTTS, CosyVoice, F5-TTS, etc.).

This enables users to use MiniMax's high-quality cloud TTS API (speech-2.8-hd / speech-2.8-turbo) **without requiring local GPU resources or model downloads** — just set the `MINIMAX_API_KEY` environment variable.

### Changes

- **New `MiniMaxCloudTTSModel`** (`modules/core/models/tts/MiniMaxCloudTTSModel.py`): Extends `TTSModel` with cloud API-based inference, 12 built-in voice IDs, emotion-based voice selection, MP3→numpy audio conversion
- **ModelZoo registration**: `minimax-hd` and `minimax-turbo` entries in the model registry
- **PipelineFactory routing**: `minimax*` model IDs routed to the new cloud pipeline
- **Configuration**: `MINIMAX_API_KEY` env var added to `.env.api`
- **README**: Updated model support table with MiniMax Cloud TTS entry
- **Tests**: 32 unit tests (mocked API) + 3 integration tests

### Usage



### MiniMax TTS Models

| Model | Description |
|-------|-------------|
|  | Higher quality, best for production use |
|  | Faster synthesis, good for real-time applications |

### Supported Voices

12 built-in voices including English_Graceful_Lady, English_Insightful_Speaker, English_Persuasive_Man, Friendly_Person, lovely_girl, Deep_Voice_Man, and more.

## Test Plan

- [x] 32 unit tests pass (mocked API, no external deps)
- [x] 3 integration tests pass (actual MiniMax API calls)
- [x] Verified both speech-2.8-hd and speech-2.8-turbo models
- [x] Verified Chinese and English text synthesis
- [x] MP3→numpy audio conversion at 24kHz
